### PR TITLE
[ASHIP-99] Split by base image and bump librdkafka to 0.11.6

### DIFF
--- a/alpine-golang-librdkafka/Dockerfile
+++ b/alpine-golang-librdkafka/Dockerfile
@@ -1,10 +1,10 @@
-FROM golang:alpine
+FROM golang:1.11.5-alpine3.8
 
 RUN apk add --no-cache --virtual .fetch-deps ca-certificates tar
 
 RUN apk add --no-cache openssl pkgconfig g++
 
-ARG LIBRDKAFKA_VERSION=0.11.5
+ARG LIBRDKAFKA_VERSION=0.11.6
 
 RUN mkdir -p /root/librdkafka
 WORKDIR /root/librdkafka

--- a/circle-golang-librdkafka/Dockerfile
+++ b/circle-golang-librdkafka/Dockerfile
@@ -1,0 +1,24 @@
+FROM circleci/golang:1.11.2
+
+ARG LIBRDKAFKA_VERSION=0.11.6
+
+RUN cd /tmp
+
+RUN wget -O "librdkafka.tar.gz" "https://github.com/edenhill/librdkafka/archive/v${LIBRDKAFKA_VERSION}.tar.gz"
+
+RUN mkdir -p librdkafka
+
+RUN tar \
+  --extract \
+  --file "librdkafka.tar.gz" \
+  --directory "librdkafka" \
+  --strip-components 1
+
+RUN cd "librdkafka" && \
+  ./configure --prefix=/usr && \
+  make && \
+  sudo make install
+
+ENV CGO_ENABLED=1 \
+  GOOS=linux \
+  GOARCH=amd64


### PR DESCRIPTION
This PR updates the structure of the repository (folders per base image) and bumps librdkafka to `v0.11.6`.


Refs: [ASHIP-99](https://unitedwardrobe.atlassian.net/browse/ASHIP-99)