### PR TITLE
Add golang 1.13.0

### DIFF
--- a/alpine-golang-librdkafka/alpine3.10-golang1.13.0-librdkafka1.1.0-static/Dockerfile
+++ b/alpine-golang-librdkafka/alpine3.10-golang1.13.0-librdkafka1.1.0-static/Dockerfile
@@ -1,0 +1,39 @@
+FROM golang:1.13.0-alpine3.10
+
+ARG LIBRDKAFKA_VERSION=1.1.0
+
+# Install all dependencies required to build the project as a static binary.
+RUN apk add -U \
+  bash \
+  build-base \
+  coreutils \
+  cyrus-sasl-dev \
+  git \
+  libevent \
+  libressl2.7-libcrypto \
+  libressl2.7-libssl \
+  libsasl \
+  lz4-dev \
+  openssh \
+  openssl \
+  openssl-dev \
+  python \
+  yajl-dev \
+  zlib-dev \
+  g++ \
+  pkgconfig \
+  --repository http://nl.alpinelinux.org/alpine/v3.10/main
+
+# SASL support is disabled for now, due to issues when compiling a static
+# binary. See: https://git.io/vAFFm
+RUN git clone https://github.com/edenhill/librdkafka.git && \
+  cd librdkafka && \
+  git checkout v${LIBRDKAFKA_VERSION} && \
+  ./configure --disable-sasl && \
+  make && \
+  make install && \
+  rm -rf librdkafka
+
+ENV CGO_ENABLED=1 \
+  GOOS=linux \
+  GOARCH=amd64

--- a/alpine-golang-librdkafka/alpine3.10-golang1.13.0-librdkafka1.1.0/Dockerfile
+++ b/alpine-golang-librdkafka/alpine3.10-golang1.13.0-librdkafka1.1.0/Dockerfile
@@ -1,0 +1,19 @@
+FROM golang:1.13.0-alpine3.10
+
+RUN apk add --no-cache openssl ca-certificates pkgconfig g++
+
+ARG LIBRDKAFKA_VERSION=1.1.0
+
+RUN apk --update add --virtual build-dependencies gcc bash python-dev build-base git && \
+  git clone https://github.com/edenhill/librdkafka.git && \
+  cd librdkafka && \
+  git checkout v${LIBRDKAFKA_VERSION} && \
+  ./configure && \
+  make && \
+  make install && \
+  apk del build-dependencies && \
+  rm -rf librdkafka
+
+ENV CGO_ENABLED=1 \
+  GOOS=linux \
+  GOARCH=amd64

--- a/circle-golang-librdkafka/circle-golang1.13.0-librdkafka1.1.0/Dockerfile
+++ b/circle-golang-librdkafka/circle-golang1.13.0-librdkafka1.1.0/Dockerfile
@@ -1,0 +1,28 @@
+FROM circleci/golang:1.13.0
+
+ARG LIBRDKAFKA_VERSION=1.1.0
+
+RUN sudo apt-get install python3-pip gettext-base
+RUN sudo pip3 install --no-cache-dir 'awscli>=1.15.50'
+RUN go get -u github.com/rubenv/sql-migrate/...
+
+RUN cd /tmp
+
+RUN wget -O "librdkafka.tar.gz" "https://github.com/edenhill/librdkafka/archive/v${LIBRDKAFKA_VERSION}.tar.gz"
+
+RUN mkdir -p librdkafka
+
+RUN tar \
+  --extract \
+  --file "librdkafka.tar.gz" \
+  --directory "librdkafka" \
+  --strip-components 1
+
+RUN cd "librdkafka" && \
+  ./configure --prefix=/usr && \
+  make && \
+  sudo make install
+
+ENV CGO_ENABLED=1 \
+  GOOS=linux \
+  GOARCH=amd64


### PR DESCRIPTION
This PR adds the golang 1.13.0 with alpine 3.10

**Tags:**
- unitedwardrobe/golang-librdkafka:alpine3.10-golang1.13.0-librdkafka1.1.0-static
- unitedwardrobe/golang-librdkafka:alpine3.10-golang1.13.0-librdkafka1.1.0
- unitedwardrobe/golang-librdkafka:circle-golang1.13.0-librdkafka1.1.0