### PR TITLE
Add alpine3.12-golang1.14.4-librdkafka1.4.4

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,9 +1,9 @@
 version: '2'
 
 vars:
-  ALPVER: 3.11
-  GOVER: 1.14.3
-  KAFKAVER: 1.4.2
+  ALPVER: 3.12
+  GOVER: 1.14.4
+  KAFKAVER: 1.4.4
 
 tasks:
   build-push:
@@ -13,21 +13,18 @@ tasks:
       - task: push-alpine
       - task: build-alpine-static
       - task: push-alpine-static
-      - task: build-circle
-      - task: push-circle
 
   build-alpine:
     desc: Build alpine image
     cmds:
       - docker build -t unitedwardrobe/golang-librdkafka:{{.TAG}} ./alpine-golang-librdkafka/{{.TAG}}
-      - docker push unitedwardrobe/golang-librdkafka:{{.TAG}}
     vars:
       TAG: alpine{{.ALPVER}}-golang{{.GOVER}}-librdkafka{{.KAFKAVER}}
 
   push-alpine:
     desc: Push alpine image
     cmds:
-      - docker build -t unitedwardrobe/golang-librdkafka:{{.TAG}} ./alpine-golang-librdkafka/{{.TAG}}
+      - docker push unitedwardrobe/golang-librdkafka:{{.TAG}}
     vars:
       TAG: alpine{{.ALPVER}}-golang{{.GOVER}}-librdkafka{{.KAFKAVER}}
 

--- a/alpine-golang-librdkafka/alpine3.12-golang1.14.4-librdkafka1.4.4-static/Dockerfile
+++ b/alpine-golang-librdkafka/alpine3.12-golang1.14.4-librdkafka1.4.4-static/Dockerfile
@@ -1,0 +1,41 @@
+FROM golang:1.14.4-alpine3.12
+
+ARG LIBRDKAFKA_VERSION=1.4.4
+
+RUN apk update
+
+# Install all dependencies required to build the project as a static binary.
+RUN apk add -U \
+  bash \
+  build-base \
+  coreutils \
+  cyrus-sasl-dev \
+  git \
+  libevent \
+  libressl2.7-libcrypto \
+  libressl2.7-libssl \
+  libsasl \
+  lz4-dev \
+  openssh \
+  openssl \
+  openssl-dev \
+  python3 \
+  yajl-dev \
+  zlib-dev \
+  g++ \
+  pkgconfig \
+  --repository http://nl.alpinelinux.org/alpine/v3.10/main
+
+# SASL support is disabled for now, due to issues when compiling a static
+# binary. See: https://git.io/vAFFm
+RUN git clone https://github.com/edenhill/librdkafka.git && \
+  cd librdkafka && \
+  git checkout v${LIBRDKAFKA_VERSION} && \
+  ./configure --disable-sasl && \
+  make && \
+  make install && \
+  rm -rf librdkafka
+
+ENV CGO_ENABLED=1 \
+  GOOS=linux \
+  GOARCH=amd64

--- a/alpine-golang-librdkafka/alpine3.12-golang1.14.4-librdkafka1.4.4/Dockerfile
+++ b/alpine-golang-librdkafka/alpine3.12-golang1.14.4-librdkafka1.4.4/Dockerfile
@@ -1,0 +1,19 @@
+FROM golang:1.14.4-alpine3.12
+
+RUN apk add --no-cache openssl ca-certificates pkgconfig g++
+
+ARG LIBRDKAFKA_VERSION=1.4.4
+
+RUN apk --update add --virtual build-dependencies python3-dev gcc bash build-base git && \
+  git clone https://github.com/edenhill/librdkafka.git && \
+  cd librdkafka && \
+  git checkout v${LIBRDKAFKA_VERSION} && \
+  ./configure && \
+  make && \
+  make install && \
+  apk del build-dependencies && \
+  rm -rf librdkafka
+
+ENV CGO_ENABLED=1 \
+  GOOS=linux \
+  GOARCH=amd64

--- a/circle-golang-librdkafka/circle-golang1.14.4-librdkafka1.4.4/Dockerfile
+++ b/circle-golang-librdkafka/circle-golang1.14.4-librdkafka1.4.4/Dockerfile
@@ -1,0 +1,29 @@
+FROM circleci/golang:1.14.4
+
+ARG LIBRDKAFKA_VERSION=1.4.4
+
+RUN sudo apt-get update
+RUN sudo apt-get install python3-pip gettext-base
+RUN sudo pip3 install --no-cache-dir 'awscli>=1.15.50'
+RUN go get -u github.com/rubenv/sql-migrate/...
+
+RUN cd /tmp
+
+RUN wget -O "librdkafka.tar.gz" "https://github.com/edenhill/librdkafka/archive/v${LIBRDKAFKA_VERSION}.tar.gz"
+
+RUN mkdir -p librdkafka
+
+RUN tar \
+  --extract \
+  --file "librdkafka.tar.gz" \
+  --directory "librdkafka" \
+  --strip-components 1
+
+RUN cd "librdkafka" && \
+  ./configure --prefix=/usr && \
+  make && \
+  sudo make install
+
+ENV CGO_ENABLED=1 \
+  GOOS=linux \
+  GOARCH=amd64


### PR DESCRIPTION
Saw Thijs using an image yesterday. Thought "maybe there are some updates available". There are. Alpine 3.12 has removed python2 from the base image, which is why python3 is being installed.

Untested, but pushed.

Didn't update the circle image, because I don't think we need that very often any more.