### PR TITLE
Add alpine-golang image

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -2,40 +2,46 @@ version: '2'
 
 vars:
   ALPVER: 3.12
-  GOVER: 1.14.6
-  KAFKAVER: 1.4.4
+  GOVER: 1.15
+  KAFKAVER: 1.5.0
 
 tasks:
-  build-push:
-    desc: Build and push all images
-    cmds:
-      - task: build-alpine
-      - task: push-alpine
-      - task: build-alpine-static
-      - task: push-alpine-static
-
   build-alpine:
     desc: Build alpine image
+    cmds:
+      - docker build -t unitedwardrobe/alpine-golang:{{.TAG}} ./alpine-golang/{{.TAG}}
+    vars:
+      TAG: alpine{{.ALPVER}}-golang{{.GOVER}}
+
+  push-alpine:
+    desc: Push alpine image
+    cmds:
+      - docker push unitedwardrobe/alpine-golang:{{.TAG}}
+    vars:
+      TAG: alpine{{.ALPVER}}-golang{{.GOVER}}
+
+  build-alpine-librdkafka:
+    desc: Build alpine librdkafka image
     cmds:
       - docker build -t unitedwardrobe/golang-librdkafka:{{.TAG}} ./alpine-golang-librdkafka/{{.TAG}}
     vars:
       TAG: alpine{{.ALPVER}}-golang{{.GOVER}}-librdkafka{{.KAFKAVER}}
 
-  push-alpine:
-    desc: Push alpine image
+  push-alpine-librdkafka:
+    desc: Push alpine librdkafka image
     cmds:
       - docker push unitedwardrobe/golang-librdkafka:{{.TAG}}
     vars:
       TAG: alpine{{.ALPVER}}-golang{{.GOVER}}-librdkafka{{.KAFKAVER}}
 
-  build-alpine-static:
+  build-alpine-librdkafka-static:
     desc: Build alpine static image
     cmds:
       - docker build -t unitedwardrobe/golang-librdkafka:{{.TAG}} ./alpine-golang-librdkafka/{{.TAG}}
     vars:
       TAG: alpine{{.ALPVER}}-golang{{.GOVER}}-librdkafka{{.KAFKAVER}}-static
 
-  push-alpine-static:
+  push-alpine-librdkafka-static:
     desc: Push alpine static image
     cmds:
       - docker push unitedwardrobe/golang-librdkafka:{{.TAG}}

--- a/alpine-golang/alpine3.12-golang1.15/Dockerfile
+++ b/alpine-golang/alpine3.12-golang1.15/Dockerfile
@@ -1,0 +1,5 @@
+FROM golang:1.15-alpine
+
+RUN apk update
+
+RUN apk add -U build-base


### PR DESCRIPTION
This adds a build image based solely on golang:1.15-alpine.

Since with the new confluent-go-kafka version no actual installation of Kafka is required anymore, we can build apps in a golang-alpine container with nothing but go and alpine (and build tools). This image is smaller than the one with librdkafka and will thus download a bit smaller, resulting in faster pipelines.